### PR TITLE
Bump version to 1.0.2 and update plugin ID and name in plugin.xml

### DIFF
--- a/OasisPALM-IDEA/build.gradle.kts
+++ b/OasisPALM-IDEA/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "org.openalgebra"
-version = "1.0.1"
+version = "1.0.2"
 
 repositories {
     mavenLocal()

--- a/OasisPALM-IDEA/src/main/resources/META-INF/plugin.xml
+++ b/OasisPALM-IDEA/src/main/resources/META-INF/plugin.xml
@@ -1,11 +1,11 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
     <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
-    <id>org.openalgebra.OasisPALM-IDEA</id>
+    <id>org.openalgebra.OasisPALM</id>
 
     <!-- Public plugin name should be written in Title Case.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/best-practices-for-listing.html#plugin-name -->
-    <name>OasisPALM-IDEA</name>
+    <name>OasisPALM</name>
 
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor url="https://oasis.openalgebra.org">Oasis</vendor>
@@ -15,6 +15,8 @@
     <description><![CDATA[
 OasisPALM-IDEA is an IntelliJ IDEA plugin that provides support for the OasisPALM modeling language. It includes syntax highlighting and error annotations.
     ]]></description>
+
+    <idea-version since-build="241.1"/>
 
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->

--- a/OasisPALM-IDEA/src/main/resources/META-INF/plugin.xml
+++ b/OasisPALM-IDEA/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
     <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
-    <id>org.openalgebra.OasisPALM</id>
+    <id>org.openalgebra.OasisPALM-IDEA</id>
 
     <!-- Public plugin name should be written in Title Case.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/best-practices-for-listing.html#plugin-name -->

--- a/OasisPALM-IDEA/src/main/resources/META-INF/plugin.xml
+++ b/OasisPALM-IDEA/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
 OasisPALM is an IntelliJ IDEA plugin that provides support for the OasisPALM modeling language. It includes syntax highlighting and error annotations.
     ]]></description>
 
-    <idea-version since-build="241.1"/>
+    <idea-version since-build="251"/>
 
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->

--- a/OasisPALM-IDEA/src/main/resources/META-INF/plugin.xml
+++ b/OasisPALM-IDEA/src/main/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/best-practices-for-listing.html#plugin-description -->
     <description><![CDATA[
-OasisPALM-IDEA is an IntelliJ IDEA plugin that provides support for the OasisPALM modeling language. It includes syntax highlighting and error annotations.
+OasisPALM is an IntelliJ IDEA plugin that provides support for the OasisPALM modeling language. It includes syntax highlighting and error annotations.
     ]]></description>
 
     <idea-version since-build="241.1"/>


### PR DESCRIPTION
This pull request updates the plugin to reflect a new name and version, and adds compatibility information for IntelliJ IDEA. The most important changes are grouped below.

**Plugin Metadata Updates:**

* Changed the plugin ID and name from `OasisPALM-IDEA` to `OasisPALM` in `plugin.xml` to standardize branding.
* Updated the plugin version from `1.0.1` to `1.0.2` in `build.gradle.kts` to reflect a new release.

**Compatibility Improvements:**

* Added the `idea-version` tag with `since-build="241.1"` in `plugin.xml` to specify the minimum supported IntelliJ IDEA version.